### PR TITLE
support multiple mkconf_lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ dpb_proot_config:
   mkconf_tail: /dev/null
 ```
 
-Note that the role assumes that `/etc/mk.conf` exists in the `chroot` after
-play. Do not omit `mkconf_tail`, or play would fail. Even if you do not need
-`mkconf_tail`, set the variable to `/dev/null`.
+Do not omit `mkconf_tail` when `mkconf_lines` is set. `proot` has a bug and
+`mk.conf` will not be created under certain conditions. See comments in Example
+Playbook. Set the variable to `/dev/null` even when you do not use it just in
+case.
 
 ## `dpb_proot_chroot` and `dpb_remove_nodev_mount_option`
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ None
 This is a dict for `proot`. Each key is described in
 [`proot(1)`](http://man.openbsd.org/proot) man page.
 
-Values are string except `actions`. `actions` is a list of actions.
+Values are string except `actions` and `mkconf_lines`.
+
+`actions` is a list of actions.
+
+`mkconf_lines` is a list of lines to be added to `mk.conf` in `chroot`.
 
 ```yaml
 dpb_proot_config:
@@ -52,7 +56,12 @@ dpb_proot_config:
     - unpopulate_light
     - resolve
     - copy_ports
+  mkconf_tail: /dev/null
 ```
+
+Note that the role assumes that `/etc/mk.conf` exists in the `chroot` after
+play. Do not omit `mkconf_tail`, or play would fail. Even if you do not need
+`mkconf_tail`, set the variable to `/dev/null`.
 
 ## `dpb_proot_chroot` and `dpb_remove_nodev_mount_option`
 
@@ -88,6 +97,28 @@ None
       - net/rsync
       - sysutils/ansible
       - net/curl
+    dpb_proot_config:
+      chroot: "{{ dpb_proot_chroot }}"
+      BUILD_USER: "{{ dpb_build_user }}"
+      FETCH_USER: "{{ dpb_fetch_user }}"
+      chown_all: 1
+      actions:
+        - unpopulate_light
+        - resolve
+        - copy_ports
+      # XXX when `mkconf_lines` contains something, `proot` should create
+      # `mk.conf`, but it does not. it does when:
+      #
+      # * "some directory values are different from the default"
+      # * or `mkconf_tail` is not empty
+      #
+      # set `mkconf_tail` here to ensure `mk.conf` is always created. if one of
+      # attributes related to `mk.conf`, such as `PORTSDIR`, is different from
+      # the defaults, `mkconf_tail` can be removed.
+      mkconf_tail: /dev/null
+      mkconf_lines:
+        - FETCH_CMD = /usr/bin/ftp -E
+        - FETCH_CMD = /usr/bin/ftp -E
     # XXX this is not recommended but the box does not have additional
     # partition.
     dpb_remove_nodev_mount_option: yes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,6 @@ dpb_proot_config:
   actions:
     - unpopulate_light
     - resolve
-  mkconf_tail: /dev/null
     - copy_ports
+  mkconf_tail: /dev/null
 dpb_remove_nodev_mount_option: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,5 +26,6 @@ dpb_proot_config:
   actions:
     - unpopulate_light
     - resolve
+  mkconf_tail: /dev/null
     - copy_ports
 dpb_remove_nodev_mount_option: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,8 +86,8 @@
   template:
     src: proot.conf.j2
     dest: "{{ dpb_proot_conf_file }}"
-  notifies:
-    - Update chroot
+    notifies:
+      - Update chroot
 
 - name: Create chroot
   command: "proot -c {{ dpb_proot_conf_file }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,8 +86,8 @@
   template:
     src: proot.conf.j2
     dest: "{{ dpb_proot_conf_file }}"
-    notifies:
-      - Update chroot
+  notify:
+    - Update chroot
 
 - name: Create chroot
   command: "proot -c {{ dpb_proot_conf_file }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,10 +86,12 @@
   template:
     src: proot.conf.j2
     dest: "{{ dpb_proot_conf_file }}"
+  notifies:
+    - Update chroot
 
 - name: Create chroot
   command: "proot -c {{ dpb_proot_conf_file }}"
   args:
-    creates: "{{ dpb_proot_chroot }}/usr/ports/Makefile"
+    creates: "{{ dpb_proot_chroot }}/etc/mk.conf"
 
 # dpb -P /etc/dpb/packages.dpb -B /usr/local/build

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,10 +88,3 @@
     dest: "{{ dpb_proot_conf_file }}"
   notify:
     - Update chroot
-
-- name: Create chroot
-  command: "proot -c {{ dpb_proot_conf_file }}"
-  args:
-    creates: "{{ dpb_proot_chroot }}/etc/mk.conf"
-
-# dpb -P /etc/dpb/packages.dpb -B /usr/local/build

--- a/templates/proot.conf.j2
+++ b/templates/proot.conf.j2
@@ -5,6 +5,10 @@
 {% for i in v %}
   {{ i }}
 {% endfor %}
+{% elif k == 'mkconf_lines' %}
+{% for i in v %}
+{{ k }}={{ i }}
+{% endfor %}
 {% else %}
 {{ k }}={{ v }}
 {% endif %}

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -13,6 +13,28 @@
       - net/rsync
       - sysutils/ansible
       - net/curl
+    dpb_proot_config:
+      chroot: "{{ dpb_proot_chroot }}"
+      BUILD_USER: "{{ dpb_build_user }}"
+      FETCH_USER: "{{ dpb_fetch_user }}"
+      chown_all: 1
+      actions:
+        - unpopulate_light
+        - resolve
+        - copy_ports
+      # XXX when `mkconf_lines` contains something, `proot` should create
+      # `mk.conf`, but it does not. it does when:
+      #
+      # * "some directory values are different from the default"
+      # * or `mkconf_tail` is not empty
+      #
+      # set `mkconf_tail` here to ensure `mk.conf` is always created. if one of
+      # attributes related to `mk.conf`, such as `PORTSDIR`, is different from
+      # the defaults, `mkconf_tail` can be removed.
+      mkconf_tail: /dev/null
+      mkconf_lines:
+        - FETCH_CMD = /usr/bin/ftp -E
+        - FETCH_CMD = /usr/bin/ftp -E
     # XXX this is not recommended but the box does not have additional
     # partition.
     dpb_remove_nodev_mount_option: yes

--- a/tests/serverspec/default_spec.rb
+++ b/tests/serverspec/default_spec.rb
@@ -58,6 +58,15 @@ describe file(proot_config) do
   its(:content) { should match(/^FETCH_USER=#{fetch_user}$/) }
   its(:content) { should match(/^chown_all=1$/) }
   its(:content) { should match(/^actions=\s*\n\s+unpopulate_light\n\s+resolve\n\s+copy_ports\n/) }
+  its(:content) { should match(/^mkconf_lines=FETCH_CMD = #{Regexp.escape("/usr/bin/ftp -E")}\nmkconf_lines=FETCH_CMD = #{Regexp.escape("/usr/bin/ftp -E")}/) }
+end
+
+describe file("#{chroot_dir}/etc/mk.conf") do
+  it { should exist }
+  it { should be_file }
+  it { should be_owned_by "root" }
+  it { should be_grouped_into "wheel" }
+  its(:content) { should match(/^FETCH_CMD = #{Regexp.escape("/usr/bin/ftp -E")}\nFETCH_CMD = #{Regexp.escape("/usr/bin/ftp -E")}$/) }
 end
 
 describe file("/usr/local/bin/dpb") do


### PR DESCRIPTION
fixes #7

also, update chroot when `dpb_proot_config` has changed.